### PR TITLE
removed single quotes in dump cmd for windows

### DIFF
--- a/lib/android_apk.rb
+++ b/lib/android_apk.rb
@@ -5,7 +5,7 @@ class AndroidApk
   def self.analyze(filepath)
     return nil unless File.exist?(filepath)
     apk = AndroidApk.new
-    command = "aapt dump badging '" + filepath + "' 2>&1"
+    command = "aapt dump badging " + filepath + " 2>&1"
     results = `#{command}`
     if $?.exitstatus != 0 or results.index("ERROR: dump failed")
       return nil


### PR DESCRIPTION
On windows aapt complains that it cannot find the apk using the filepath, when the path is enclosed in single quotes. It works without the quotes on windows and osx.